### PR TITLE
Use piggyback for data storage/sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ While we won't be able to emulate all the beauracracy/politics associated with d
 
 ## Data Access
 
-We're using the publicly available data from the Superintendência de Seguros Privados of Brazil. The data can be downloaded from [http://www2.susep.gov.br/menuestatistica/Autoseg/principal.aspx](http://www2.susep.gov.br/menuestatistica/Autoseg/principal.aspx). We'll be using the first half of 2012 (`Autoseg2012B`) to start, since that's the first time period where CSVs (as opposed to MS Access files) are available. The convention we'll use in this repo is that we'll put the uncompressed directory in `external_data/`, so your directory structure might look something like
+We're using the publicly available data from the [Superintendência de Seguros Privados of Brazil](http://www2.susep.gov.br/menuestatistica/Autoseg/principal.aspx). The data can be downloaded using the `analysis/data-fetch.R` script. We'll be using the first half of 2012 (`Autoseg2012B`) to start, since that's the first time period where CSVs (as opposed to MS Access files) are available. The convention we'll use in this repo is that we'll put the uncompressed directory in `external_data/`, so your directory structure might look something like
 
 ```
 ├── R

--- a/analysis/data-fetch.R
+++ b/analysis/data-fetch.R
@@ -1,12 +1,11 @@
-
-library(tidyverse)
-library(fs)
-library(pricingtutorial)
-
+# Gets data from release
 
 download_dir <- path(here::here(), "external_data") 
+piggyback::pb_download("Autoseg2012B.zip", dest = download_dir)
 
-time_periods <- c("2012B", "2013A")
+unzip(
+  file.path(download_dir, "Autoseg2012B.zip"), 
+  exdir = file.path(download_dir, "Autoseg2012B")
+)
 
-download_data(time_periods, download_dir)
 


### PR DESCRIPTION
Instead of having users download the files from the SUSEP website directly, we host the files on the repo.

Fix https://github.com/kasaai/pc-pricing-tutorial/issues/85