### PR TITLE
Toy ML model for deployment example

### DIFF
--- a/analysis/uw.R
+++ b/analysis/uw.R
@@ -1,0 +1,95 @@
+library(tidyverse)
+library(recipes)
+library(tfdatasets)
+library(keras)
+source("analysis/data-prep.R")
+report_year <- 2012
+
+# Get a small subset since we're focused on the deployment aspect
+train_set <- training_data %>% 
+  sample_n(10000)
+
+# Prep recipe on training set
+rec <- recipe(train_set, ~.) %>%
+  step_mutate(
+    make = sub(" .*$", "", vehicle_group),
+    vehicle_age = pmin(pmax(!!report_year - vehicle_year, 0), 35)
+  ) %>%
+  step_other(make, threshold = 0.01) %>%
+  step_string2factor(region, sex, age_range, vehicle_category) %>%
+  step_mutate(
+    average_insured_amount = average_insured_amount / 1000,
+    region = fct_explicit_na(region),
+    make = fct_explicit_na(make),
+    vehicle_category = fct_explicit_na(vehicle_category),
+    exposure = exposure + 0.5, # see #81
+    loss_per_exposure = claim_amount / exposure
+  ) %>%
+  prep(train_set, strings_as_factors = FALSE, retain = TRUE)
+
+# feature columns don't handle factors well currently
+train_set <- juice(rec) %>% 
+  mutate_if(is.factor, as.character) %>% 
+  select(sex, vehicle_age, region, average_insured_amount, make, 
+         loss_per_exposure, exposure)
+
+# Construct feature spec
+feat_spec <- train_set %>% 
+  feature_spec(loss_per_exposure ~ sex + vehicle_age + region +
+                 average_insured_amount + make) %>% 
+  step_numeric_column(vehicle_age, average_insured_amount, 
+                      normalizer_fn = scaler_standard()) %>% 
+  step_categorical_column_with_vocabulary_list(sex, region, make) %>%
+  step_indicator_column(sex) %>%
+  step_embedding_column(region, make) %>%
+  fit()
+
+# Make a toy model
+inputs <- layer_input_from_dataset(
+  train_set %>% select(-loss_per_exposure, -exposure)
+  )
+
+output <- inputs %>% 
+  layer_dense_features(feat_spec$dense_features()) %>% 
+  layer_dense(10, activation = "relu") %>% 
+  layer_dense(1, activation = "relu")
+
+toy_model <- keras_model(inputs, output)
+
+toy_model <- keras_model_sequential(list(
+  layer_dense_features(feature_columns = feat_spec$dense_features()),
+    layer_dense(units = 10, activation = "relu"),
+    layer_dense(units = 1, activation = "relu")
+))
+
+toy_model %>% 
+  compile(optimizer = optimizer_adam(lr = 0.1), loss = "mse")
+
+history <- toy_model %>% 
+  fit(x = select(train_set, -loss_per_exposure, -exposure), 
+      y = train_set$loss_per_exposure, 
+      sample_weight = train_set$exposure,
+      batch_size = 10000, epochs = 100)
+plot(history)
+
+# `save_model_hdf5()` isn't working properly with feature columns yet, so we
+#   use this for serializing
+tensorflow::tf$keras$models$save_model(toy_model, filepath = "model_artifacts/toy_model", 
+                                       save_format = "tf")
+
+# we'll also want to remove the data frame, see
+#  https://github.com/tidymodels/butcher/issues/132
+clean_rec <- butcher::axe_env(rec, verbose = TRUE)
+saveRDS(clean_rec, "model_artifacts/recipe.rds")
+
+# Prediction
+
+toy_model_loaded <- tensorflow::tf$keras$models$load_model("model_artifacts/toy_model")
+recipe_loaded <- readRDS("model_artifacts/recipe.rds")
+
+new_data <- rec %>% 
+  bake(training_data[1,]) %>% 
+  select(sex, vehicle_age, region, average_insured_amount, make) %>% 
+  mutate_if(is.factor, as.character)
+
+predict(toy_model_loaded, new_data)


### PR DESCRIPTION
This PR adds `uw.R` which creates a toy ML model and deployable artifacts.

@chatty1406 The files produced by this script should be enough to get a prediction service going.